### PR TITLE
signature verification must be turned off for AMO

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -189,6 +189,9 @@
       following:
       <ul>
         <li>
+          <code>xpinstall.signatures.required = false</code>
+        </li>
+        <li>
           <code>xpinstall.signatures.dev-root = true</code> (this does not
           exist and must be created)
         </li>


### PR DESCRIPTION
Since we're switching to the `dev-root`, AMO add-ons no longer appear to be valid. This overrides that. We still need `dev-root` in order to get the privileged code to load.